### PR TITLE
Fix garbage output from protoc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,7 @@ fn main() {
     assert!(result.status.success());
     let output = core::str::from_utf8(&result.stdout).unwrap();
     let output = output.replace("\\\n", " ");
+    let output = output.replace("/dev/null: ", "");
     let files: Vec<&str> = output.split_ascii_whitespace().collect();
 
     // Generate Rust code from protos.


### PR DESCRIPTION
`protoc-bin-vendored` 3.1.0 upgrades `protoc` from 3.19.4 to 28.2, breaking the output from protoc and breaking the build. This fixes it (and is backward compatible with 3.0.0).