### PR TITLE
Bump protoc-bin-vendored to v3.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ protobuf = "3.7.1"
 
 [build-dependencies]
 protobuf-codegen = "3.7.1"
-protoc-bin-vendored = "3.1.0"
+protoc-bin-vendored = "3.2.0"


### PR DESCRIPTION
protoc-bin-vendored v3.2.0 contains the IBM Z (s390x) architecture support. Bumping this dependency version is enough to make perfetto_protos work there as well.